### PR TITLE
Fixed hash syntax for ruby 1.8

### DIFF
--- a/resources/monitrc.rb
+++ b/resources/monitrc.rb
@@ -1,5 +1,5 @@
 actions :create, :delete
 default_action :create
 
-attribute :name, kind_of: String, name_attribute: true
-attribute :variables, kind_of: Hash
+attribute :name, :kind_of => String, :name_attribute => true
+attribute :variables, :kind_of => Hash


### PR DESCRIPTION
Changed params hash syntax from new(1.9) to old, ruby 1.8 compatible
