### PR TITLE
support other security protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ default["monit"]["mail"] = {
   :from     => "monit@$HOST",
   :subject  => "$SERVICE $EVENT at $DATE",
   :message  => "Monit $ACTION $SERVICE at $DATE on $HOST,\n\nDutifully,\nMonit",
-  :tls      => false,
+  :tls      => nil,  # deprecated, use :security
+  :security => nil,    # 'SSLV2'|'SSLV3'|'TLSV1'
   :timeout  => 30
 }
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,7 +37,8 @@ default["monit"]["mail"] = {
   :from     => "monit@$HOST",
   :subject  => "$SERVICE $EVENT at $DATE",
   :message  => "Monit $ACTION $SERVICE at $DATE on $HOST,\n\nDutifully,\nMonit",
-  :tls      => false,
+  :tls      => nil,  # deprecated, use :security
+  :security => nil, # 'SSLV2'|'SSLV3'|'TLSV1'
   :timeout  => 30
 }
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,6 +7,14 @@ package "monit" do
   action :install
 end
 
+if node["monit"]["mail"]["tls"] != nil
+  Chef::Log.warn("node[\"monit\"][\"mail\"][\"tls\"] is deprecated. Use node[\"monit\"][\"mail\"][\"security\"] = 'SSLV2'|'SSLV3'|'TLSV1'")
+  unless node["monit"]["mail"]["security"].to_s.empty?
+    Chef::Log.warn("node[\"monit\"][\"mail\"][\"security\"] has precedence over deprecated node[\"monit\"][\"mail\"][\"tls\"]")
+  end
+end
+
+
 template node["monit"]["main_config_path"] do
   owner  "root"
   group  "root"

--- a/templates/default/monitrc.erb
+++ b/templates/default/monitrc.erb
@@ -17,9 +17,12 @@ set mailserver <%= node["monit"]["mail"]["hostname"] %> port <%= node["monit"]["
   <% if node["monit"]["mail"]["password"] -%>
   password "<%= node["monit"]["mail"]["password"] %>"
   <% end -%>
-  <% if node["monit"]["mail"]["tls"] -%>
-  using tlsv1
-  <% end -%>
+<% if node["monit"]["mail"]["tls"] and node["monit"]["mail"]["security"].to_s.empty? -%>
+    using tlsv1
+<% end -%>
+<% if node["monit"]["mail"]["security"] -%>
+    using <%=  node["monit"]["mail"]["security"] %>
+<% end -%>
   with timeout <%= node["monit"]["mail"]["timeout"] %> seconds
 
 set mail-format {


### PR DESCRIPTION
The current cookbook only supports TLS for the email security.

This pull request deprecates node[:monit][:mail][:tls] in favor of a new attribute: node[:monit][:mail][:security].
node[:monit][:mail][:security] is a string.

Warnings are logged when:
- node[:monit][:mail][:tls]  is used.
- and/or both node[:monit][:mail][:tls]  and node[:monit][:mail][:security] are set.

node[:monit][:mail][:security] has precdence over node[:monit][:mail][:tls].
