### PR TITLE
Add mail_alerts attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ default["monit"]["use_syslog"]        = true
 # If not using syslog, the log file that monit will use.
 default["monit"]["logfile"]           = "/var/log/monit.log"
 
+# Enable emails for internal monit alerts
+default["monit"]["mail_alerts"]       = true
+
 # Email address that will be notified of events.
 default["monit"]["alert_email"]       = "root@localhost"
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,9 @@ default["monit"]["use_syslog"]        = true
 # If not using syslog, the log file that monit will use.
 default["monit"]["logfile"]           = "/var/log/monit.log"
 
+# Enable emails for internal monit alerts
+default["monit"]["mail_alerts"]       = true
+
 # Email address that will be notified of events.
 default["monit"]["alert_email"]       = "root@localhost"
 

--- a/templates/default/monitrc.erb
+++ b/templates/default/monitrc.erb
@@ -8,8 +8,11 @@ set logfile syslog facility log_daemon
 set logfile <%= node["monit"]["logfile"] %>
 <% end %>
 
+<% if node['monit']['mail_alerts'] %>
 # Mail alerts
 set alert <%= node["monit"]["alert_email"] %>
+<% end %>
+
 set mailserver <%= node["monit"]["mail"]["hostname"] %> port <%= node["monit"]["mail"]["port"] %>
   <% if node["monit"]["mail"]["username"] -%>
   username "<%= node["monit"]["mail"]["username"] %>"


### PR DESCRIPTION
Allows mail alerts to be disabled in the monitrc template by setting `node[:monit][:mail_alerts]` to false.  Defaults to true so that existing chef-monit cookbook users will not be affected.
