### PR TITLE
Fix platform family logic

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -45,8 +45,8 @@ default["monit"]["mail"] = {
   :timeout  => 30
 }
 
-case node["platform"]
-when platform_family?("rhel"), platform_family?("fedora"), platform_family?("suse")
+case node["platform_family"]
+when "rhel", "fedora", "suse"
   default["monit"]["main_config_path"] = "/etc/monit.conf"
   default["monit"]["includes_dir"]     = "/etc/monit.d"
 else

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -31,11 +31,11 @@ end
 service "monit" do
   service_name "monit"
 
-  case node["platform"]
-  when platform_family?("rhel"), platform_family?("fedora"), platform_family?("suse")
+  case node["platform_family"]
+  when "rhel", "fedora", "suse"
     start_command "/sbin/service monit start"
     restart_command "/sbin/service monit restart"
-  when platform_family?("debian")
+  when "debian"
     start_command "/usr/sbin/invoke-rc.d monit start"
     restart_command "/usr/sbin/invoke-rc.d monit restart"
   end


### PR DESCRIPTION
Not sure what was going in with the existing code. I seemed that it was written on ubuntu and never tested on rhel as all of the platform_family logic was falling into the else block, or something about what Chef11 returns from an attribute no longer support platform_family?.

In either case, I tweaked the attributes file to do the when checks against the platform_family attribute directly in the case/when blocks.
