### PR TITLE
fix logging logic in template

### DIFF
--- a/templates/default/monitrc.erb
+++ b/templates/default/monitrc.erb
@@ -5,9 +5,9 @@ set daemon <%= node["monit"]["polling_frequency"] %>
 <% end -%>
 
 # Logging
-<% if node["monit"]["syslog"] == "true" %>
+<% if node["monit"]["syslog"] == true or node["monit"]["syslog"] == "true" %>
 set logfile syslog facility log_daemon
-<% else %>
+<% elsif node["monit"]["logfile"] %>
 set logfile <%= node["monit"]["logfile"] %>
 <% end %>
 


### PR DESCRIPTION
The default attribute for syslog is not a string. Also, no logging should be an option.
