### PR TITLE
added option "alert_ignore_events" to avoid certain types of event alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ default["monit"]["logfile"]           = "/var/log/monit.log"
 # Enable emails for internal monit alerts
 default["monit"]["mail_alerts"]       = true
 
+# Ignore alerts for specific events
+# Possible events include: action, checksum, connection, content, data, exec, fsflags, gid, icmp, instance, invalid, nonexist, permission, pid, ppid, resource, size, status, timeout, timestamp, uid, uptime.
+default["monit"]["alert_ignore_events"] = []
+
 # Email address that will be notified of events.
 default["monit"]["alert_email"]       = "root@localhost"
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,6 +21,10 @@ default["monit"]["logfile"]           = "/var/log/monit.log"
 # Enable emails for internal monit alerts
 default["monit"]["mail_alerts"]       = true
 
+# Ignore alerts for specific events
+# Possible events include: action, checksum, connection, content, data, exec, fsflags, gid, icmp, instance, invalid, nonexist, permission, pid, ppid, resource, size, status, timeout, timestamp, uid, uptime.
+default["monit"]["alert_ignore_events"] = []
+
 # Email address that will be notified of events.
 default["monit"]["alert_email"]       = "root@localhost"
 

--- a/templates/default/monitrc.erb
+++ b/templates/default/monitrc.erb
@@ -13,7 +13,7 @@ set logfile <%= node["monit"]["logfile"] %>
 
 <% if node['monit']['mail_alerts'] %>
 # Mail alerts
-set alert <%= node["monit"]["alert_email"] %>
+set alert <%= node["monit"]["alert_email"] %> <%= node["monit"]["alert_ignore_events"].empty? ? "" : "but not on { #{node["monit"]["alert_ignore_events"].join(", ")} }" %>
 <% end %>
 
 set mailserver <%= node["monit"]["mail"]["hostname"] %> port <%= node["monit"]["mail"]["port"] %>


### PR DESCRIPTION
Added attribute default["monit"]["alert_ignore_events"] to ignore alerts for specific events.

For example, the following attribute

default["monit"]["alert_ignore_events"] = ["instance", "uptime"]

Will generate the following alert statement on monitrc:

alert foo@bar but not on { instance, uptime }
