### PR TITLE
Added reload_on_change property that defines if monit should be reloaded when configuration changes (default: true)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,10 @@ end
 # The monit::default recipe will load these monit_monitrc resources automatically
 # NOTE setting this attribute at the default level will append values to the array
 default["monit"]["default_monitrc_configs"] = ["load", "ssh"]
-```
 
+# Whether the monit service should be reloaded when a configuration changes
+default["monit"]["reload_on_change"] = true
+```
 
 ## Contributors
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -61,3 +61,6 @@ end
 # The monit::default recipe will load these monit_monitrc resources automatically
 # NOTE setting this attribute at the default level will append values to the array
 default["monit"]["default_monitrc_configs"] = ["load", "ssh"]
+
+# Whether the monit service should be reloaded when a configuration changes
+default["monit"]["reload_on_change"] = true

--- a/providers/monitrc.rb
+++ b/providers/monitrc.rb
@@ -11,7 +11,9 @@ action :create do
     cookbook new_resource.template_cookbook
     variables new_resource.variables
     action :create
-    notifies :reload, "service[monit]", :delayed
+    if node["monit"]["reload_on_change"]
+        notifies :reload, "service[monit]", :delayed
+    end
   end
 
   new_resource.updated_by_last_action(t.updated_by_last_action?)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -11,7 +11,9 @@ template node["monit"]["main_config_path"] do
   group  "root"
   mode   "0600"
   source "monitrc.erb"
-  notifies :reload, "service[monit]", :delayed
+  if node["monit"]["reload_on_change"]
+      notifies :reload, "service[monit]", :delayed
+  end
 end
 
 directory "/var/monit" do


### PR DESCRIPTION
The reload when configuration change feature was making monit start when I was bootstrapping my node, but I wanted to avoid this behavior, otherwise monit will start services that are not ready to start yet. So, setting this value to false will avoid monit to be started during bootstrap.
