### PR TITLE
Allow either style of monit startup flag to work

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,8 +22,9 @@ end
 
 # enable service startup
 execute "enable-monit-startup" do
-  command "/bin/sed s/START=no/START=yes/ -i /etc/default/monit"
-  not_if "grep 'START=yes' /etc/default/monit"
+  command "/bin/sed -e s/startup=0/startup=1/ -e s/START=no/START=yes/ \
+          -i /etc/default/monit"
+  not_if "grep -e 'startup=1' -e 'START=yes' /etc/default/monit"
   only_if { platform_family?("debian") }
 end
 


### PR DESCRIPTION
Monit packages for Ubuntu 10.04 use the older "startup=0|startup=1" syntax, while 12.04 and newer use the "START=no|START=yes" syntax.  This change allows either style to be detected & updated.
