### PR TITLE
Fix bug in which Monit is not started during bootstrap

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -37,12 +37,13 @@ execute "enable-monit-startup" do
           -i /etc/default/monit"
   not_if "grep -e 'startup=1' -e 'START=yes' /etc/default/monit"
   only_if { platform_family?("debian") }
+  notifies :restart, "service[monit]"
 end
 
 # system service
 service "monit" do
   supports restart: true, start: true, reload: true
-  action :enable
+  action [:enable, :start]
 
   case node["platform_family"]
   when "rhel", "fedora", "suse"


### PR DESCRIPTION
I ran into this bug in which Monit never actually starts when bootstrapping a new node. Most of the craziness is obscured due to the fact that both 'monit reload' and '/etc/init.d/monit start' report exit status 0 after failure (examples below). This causes chef to believe Monit is running.

This fix includes two modifications:
- Don't just enable the monit service, but start it too (service[monit] action start)
- Notify Monit for restart (not reload) when we update the defaults file

Supplemental proof of Monit silliness:

``` shell
vagrant@box01:~$ sudo /etc/init.d/monit start
Starting daemon monitor: monit won't be started/stopped
unless it it's configured
please configure monit and then edit /etc/default/monit
and set the "startup" variable to 1 in order to allow
monit to start
vagrant@box01:~$ echo $?
0
vagrant@box01:~$
vagrant@box01:~$
vagrant@box01:~$ sudo monit reload
monit: generated unique Monit id 6fa3ee32626bfa5e4776aa641fc2241a and stored to '/root/.monit.id'
Reinitializing monit daemon
monit: No daemon process found
vagrant@box01:~$ echo $?
0
```
