### PR TITLE
Support Amazon Linux for ssh

### DIFF
--- a/templates/amazon/ssh.monitrc.erb
+++ b/templates/amazon/ssh.monitrc.erb
@@ -1,0 +1,5 @@
+check process sshd with pidfile /var/run/sshd.pid
+  start program "/sbin/service sshd start"
+  stop program "/sbin/service sshd stop"
+  if failed port 22 protocol ssh then restart
+  if 5 restarts within 5 cycles then timeout


### PR DESCRIPTION
Amazon Linux uses the sshd program.

The default template which uses /etc/init.d/ssh does not work correctly.
