### PR TITLE
Support 'using HOSTNAME' syntax

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -54,7 +54,7 @@ default["monit"]["mail"] = {
   message:  "Monit $ACTION $SERVICE at $DATE on $HOST,\n\n$DESCRIPTION\n\nDutifully,\nMonit",
   security: nil,  # 'SSLV2'|'SSLV3'|'TLSV1'
   timeout:  30,
-  hostname: nil
+  using_hostname: nil
 }
 
 case node["platform_family"]

--- a/templates/default/monitrc.erb
+++ b/templates/default/monitrc.erb
@@ -37,8 +37,8 @@ set mailserver <%= node["monit"]["mail"]["hostname"] %> port <%= node["monit"]["
     using <%= node["monit"]["mail"]["security"] %>
 <% end -%>
   with timeout <%= node["monit"]["mail"]["timeout"] %> seconds
-<% if node["monit"]["mail"]["hostname"] -%>
-    using hostname <%= node["monit"]["mail"]["hostname"] %>
+<% if node["monit"]["mail"]["using_hostname"] -%>
+    using hostname <%= node["monit"]["mail"]["using_hostname"] %>
 <% end -%>
 
 set mail-format {


### PR DESCRIPTION
This provides support for configuring monitrc with hostnames as per documentation:

```
SET MAILSERVER <hostname|ip-address [PORT number] [USERNAME string] [PASSWORD string] [using SSLAUTO|SSLV2|SSLV3|TLSV1|TLSV11|TLSV12] [CERTMD5 checksum]>, ...
                [with TIMEOUT X SECONDS]
                [using HOSTNAME hostname]
```
