### PR TITLE
Make pid file path customisable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,6 +11,9 @@ default["monit"]["start_delay"] = 0
 # How frequently the monit daemon polls for changes.
 default["monit"]["polling_frequency"] = 20
 
+# Where Monit stores the pid file
+default["monit"]["pidfile"] = "/var/run/monit.pid"
+
 # Use syslog for logging instead of a logfile.
 default["monit"]["use_syslog"] = true
 

--- a/recipes/install_binary.rb
+++ b/recipes/install_binary.rb
@@ -28,7 +28,8 @@ template "/etc/init.d/monit" do
   mode "0755"
   variables(
     prefix: node["monit"]["binary"]["prefix"],
-    config: node["monit"]["main_config_path"]
+    config: node["monit"]["main_config_path"],
+    pidfile: node["monit"]["pidfile"]
   )
 end
 

--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -64,7 +64,8 @@ template "/etc/init.d/monit" do
   mode "0755"
   variables(
     prefix: source_opts["prefix"],
-    config: node["monit"]["main_config_path"]
+    config: node["monit"]["main_config_path"],
+    pidfile: node["monit"]["pidfile"]
   )
 end
 

--- a/templates/default/monit.init.erb
+++ b/templates/default/monit.init.erb
@@ -26,7 +26,7 @@ CONFIG="<%= @config %>"
 NAME=monit
 DESC="daemon monitor"
 MONIT_OPTS=
-PID="/run/$NAME.pid"
+PID="<%= @pidfile %>"
 
 # Check if DAEMON binary exist
 [ -f $DAEMON ] || exit 0

--- a/templates/default/monit.init.erb
+++ b/templates/default/monit.init.erb
@@ -55,6 +55,7 @@ monit_checks () {
 
 case "$1" in
   start)
+    mkdir -p $(dirname $PID)
     log_daemon_msg "Starting $DESC" "$NAME"
     monit_checks $1
     if start-stop-daemon --start --quiet --oknodo --pidfile $PID --exec $DAEMON -- $MONIT_OPTS 1>/dev/null

--- a/templates/default/monitrc.erb
+++ b/templates/default/monitrc.erb
@@ -11,6 +11,11 @@ set logfile syslog facility log_daemon
 set logfile <%= node["monit"]["logfile"] %>
 <% end %>
 
+# Set location of Monit pid file
+<% if node["monit"]["pidfile"] %>
+set pidfile <%= node["monit"]["pidfile"] %>
+<% end %>
+
 # Set location of Monit id file
 <% if node["monit"]["idfile"] %>
 set idfile <%= node["monit"]["idfile"] %>


### PR DESCRIPTION
By specifying the pidfile in `monitrc` and specifying the same pidfile in the init script, the command line `monit` and `service monit <command>` will refer to the same monit instance.