### PR TITLE
add use_inline_resources to monit_monitrc provider

### DIFF
--- a/providers/monitrc.rb
+++ b/providers/monitrc.rb
@@ -2,6 +2,8 @@ def whyrun_supported?
   true
 end
 
+use_inline_resources if defined?(use_inline_resources)
+
 action :create do
   name = new_resource.name
 


### PR DESCRIPTION
you can't use the monit_monitrc LWRP within your own LWRP without inline_resources as it can't notify service[monit].
