### PR TITLE
Adds support for multiple email recipients

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ default["monit"]["mail_alerts"] = true
 # Possible events include: action, checksum, connection, content, data, exec, fsflags, gid, icmp, instance, invalid, nonexist, permission, pid, ppid, resource, size, status, timeout, timestamp, uid, uptime.
 default["monit"]["alert_ignore_events"] = []
 
-# Email address that will be notified of events.
+# Email addresses that will be notified of events. Can take an array for multiple emails.
 default["monit"]["alert_email"] = "root@localhost"
 
 # Enable the web interface and define credentials.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,8 +30,8 @@ default["monit"]["mail_alerts"] = true
 # Possible events include: action, checksum, connection, content, data, exec, fsflags, gid, icmp, instance, invalid, nonexist, permission, pid, ppid, resource, size, status, timeout, timestamp, uid, uptime.
 default["monit"]["alert_ignore_events"] = []
 
-# Email address that will be notified of events.
-default["monit"]["alert_email"] = "root@localhost"
+# Email addresses that will be notified of events.
+default["monit"]["alert_emails"] = ["root@localhost"]
 
 # Enable the web interface and define credentials.
 default["monit"]["web_interface"] = {

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,8 +30,7 @@ default["monit"]["mail_alerts"] = true
 # Possible events include: action, checksum, connection, content, data, exec, fsflags, gid, icmp, instance, invalid, nonexist, permission, pid, ppid, resource, size, status, timeout, timestamp, uid, uptime.
 default["monit"]["alert_ignore_events"] = []
 
-# Email addresses that will be notified of events.
-default["monit"]["alert_emails"] = ["root@localhost"]
+# Email addresses that will be notified of events. Can take an array for multiple emails.
 default["monit"]["alert_email"] = "root@localhost"
 
 # Enable the web interface and define credentials.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,6 +32,7 @@ default["monit"]["alert_ignore_events"] = []
 
 # Email addresses that will be notified of events.
 default["monit"]["alert_emails"] = ["root@localhost"]
+default["monit"]["alert_email"] = "root@localhost"
 
 # Enable the web interface and define credentials.
 default["monit"]["web_interface"] = {

--- a/templates/default/monitrc.erb
+++ b/templates/default/monitrc.erb
@@ -23,7 +23,9 @@ set statefile <%= node["monit"]["statefile"] %>
 
 <% if node['monit']['mail_alerts'] %>
 # Mail alerts
-set alert <%= node["monit"]["alert_email"] %> <%= node["monit"]["alert_ignore_events"].empty? ? "" : "but not on { #{node["monit"]["alert_ignore_events"].join(", ")} }" %>
+  <% node["monit"]["alert_emails"].each do | email | %>
+    set alert <%= email %> <%= node["monit"]["alert_ignore_events"].empty? ? "" : "but not on { #{node["monit"]["alert_ignore_events"].join(", ")} }" %>
+  <% end %>
 <% end %>
 
 set mailserver <%= node["monit"]["mail"]["hostname"] %> port <%= node["monit"]["mail"]["port"] %>

--- a/templates/default/monitrc.erb
+++ b/templates/default/monitrc.erb
@@ -23,12 +23,9 @@ set statefile <%= node["monit"]["statefile"] %>
 
 <% if node["monit"]["mail_alerts"] %>
 # Mail alerts
-  <% node["monit"]["alert_emails"].each do | email | %>
+  <% Array(node["monit"]["alert_email"]).each do | email | %>
     set alert <%= email %> <%= node["monit"]["alert_ignore_events"].empty? ? "" : "but not on { #{node["monit"]["alert_ignore_events"].join(", ")} }" %>
   <% end %>
-<% end %>
-<% if node["monit"]["alert_email"] %>
-  set alert <%= node["monit"]["alert_email"] %>
 <% end %>
 
 set mailserver <%= node["monit"]["mail"]["hostname"] %> port <%= node["monit"]["mail"]["port"] %>

--- a/templates/default/monitrc.erb
+++ b/templates/default/monitrc.erb
@@ -21,11 +21,14 @@ set idfile <%= node["monit"]["idfile"] %>
 set statefile <%= node["monit"]["statefile"] %>
 <% end %>
 
-<% if node['monit']['mail_alerts'] %>
+<% if node["monit"]["mail_alerts"] %>
 # Mail alerts
   <% node["monit"]["alert_emails"].each do | email | %>
     set alert <%= email %> <%= node["monit"]["alert_ignore_events"].empty? ? "" : "but not on { #{node["monit"]["alert_ignore_events"].join(", ")} }" %>
   <% end %>
+<% end %>
+<% if node["monit"]["alert_email"] %>
+  set alert <%= node["monit"]["alert_email"] %>
 <% end %>
 
 set mailserver <%= node["monit"]["mail"]["hostname"] %> port <%= node["monit"]["mail"]["port"] %>


### PR DESCRIPTION
As discussed [here](http://lists.nongnu.org/archive/html/monit-general/2007-06/msg00030.html) using `set alert` multiple times will set multiple recipients. The changes I made reflect this with `:alert_email` being changed to `:alert_emails` and making it take an array of emails.
