### PR TITLE
Fixing LWRP's updated_by_last_action setting

### DIFF
--- a/providers/monitrc.rb
+++ b/providers/monitrc.rb
@@ -15,6 +15,9 @@ action :create do
     notifies :reload, "service[monit]" if node["monit"]["reload_on_change"]
   end
 
+  # Run the action immediately so the LWRP's updated_by_last_action setting is correct
+  t.run_action(:create)
+
   new_resource.updated_by_last_action(t.updated_by_last_action?)
 end
 
@@ -23,6 +26,9 @@ action :delete do
     action :delete
     notifies :reload, "service[monit]"
   end
+
+  # Run the action immediately so the LWRP's updated_by_last_action setting is correct
+  f.run_action(:delete)
 
   new_resource.updated_by_last_action(f.updated_by_last_action?)
 end

--- a/providers/monitrc.rb
+++ b/providers/monitrc.rb
@@ -13,6 +13,7 @@ action :create do
     cookbook new_resource.template_cookbook
     variables new_resource.variables
     notifies :reload, "service[monit]" if node["monit"]["reload_on_change"]
+    action :nothing
   end
 
   # Run the action immediately so the LWRP's updated_by_last_action setting is correct
@@ -23,7 +24,7 @@ end
 
 action :delete do
   f = file "#{node["monit"]["includes_dir"]}/#{new_resource.name}.monitrc" do
-    action :delete
+    action :nothing
     notifies :reload, "service[monit]"
   end
 


### PR DESCRIPTION
Since the LWRP's sub-resources are not executed until after the action
completes, the LWRP's updated_by_last_action flag is always false. By
running the actions immediately, we can correctly set the parent LWRP's
notification flag.