### PR TITLE
Much needed updates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,10 @@ LineLength:
     - "**/attributes/*.rb"
     - "**/metadata.rb"
 
-StringLiterals:
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
 
 PercentLiteralDelimiters:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 bundler_args: --without integration
 rvm:
-- 1.9.3
 - 2.0.0
-- 2.1.2
+- 2.1.6
+- 2.2.2
 script:
 - bundle exec rake rubocop
 - bundle exec rake foodcritic

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "berkshelf", "~> 3.1.3"
 gem "foodcritic", "~> 4.0.0"
 gem "rake"
 gem "rspec", "~> 2.99"
-gem "rubocop", "~> 0.23.0"
+gem "rubocop", "~> 0.23"
 gem "serverspec", "~> 1.9.0"
 
 group :integration do

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/Glassdoor/chef-monit.svg?branch=master)](https://travis-ci.org/Glassdoor/chef-monit)
+
 # chef-monit
 
 ## Description

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-[![Build Status](https://travis-ci.org/Glassdoor/chef-monit.svg?branch=master)](https://travis-ci.org/Glassdoor/chef-monit)
-
-# chef-monit
+# chef-monit  [![Build Status](http://img.shields.io/travis-ci/phlipper/chef-monit.png)](http://travis-ci.org/phlipper/chef-monit)
 
 ## Description
 
@@ -210,5 +208,8 @@ Many thanks go to the following [contributors](https://github.com/phlipper/chef-
 
 **chef-monit**
 
-* Freely distributable and licensed under the MIT license
-* Copyright (c) 2011-2014 Phil Cohen (github@phlippers.net)
+* Freely distributable and licensed under the [MIT license](http://phlipper.mit-license.org/2011-2014/license.html).
+* Copyright (c) 2011-2014 Phil Cohen (github@phlippers.net) [![endorse](http://api.coderwall.com/phlipper/endorsecount.png)](http://coderwall.com/phlipper)  [![Gittip](http://img.shields.io/gittip/phlipper.png)](https://www.gittip.com/phlipper/)
+* http://phlippers.net/
+
+[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/phlipper/chef-monit/trend.png)](https://bitdeli.com/free "Bitdeli Badge")

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# chef-monit  [![Build Status](http://img.shields.io/travis-ci/phlipper/chef-monit.png)](http://travis-ci.org/phlipper/chef-monit)
+# chef-monit
 
 ## Description
 
@@ -208,8 +208,5 @@ Many thanks go to the following [contributors](https://github.com/phlipper/chef-
 
 **chef-monit**
 
-* Freely distributable and licensed under the [MIT license](http://phlipper.mit-license.org/2011-2014/license.html).
-* Copyright (c) 2011-2014 Phil Cohen (github@phlippers.net) [![endorse](http://api.coderwall.com/phlipper/endorsecount.png)](http://coderwall.com/phlipper)  [![Gittip](http://img.shields.io/gittip/phlipper.png)](https://www.gittip.com/phlipper/)
-* http://phlippers.net/
-
-[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/phlipper/chef-monit/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
+* Freely distributable and licensed under the MIT license
+* Copyright (c) 2011-2014 Phil Cohen (github@phlippers.net)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,8 +26,10 @@ default["monit"]["statefile"] = "/var/lib/monit/state"
 # Enable emails for internal monit alerts
 default["monit"]["mail_alerts"] = true
 
-# Ignore alerts for specific events
 # Possible events include: action, checksum, connection, content, data, exec, fsflags, gid, icmp, instance, invalid, nonexist, permission, pid, ppid, resource, size, status, timeout, timestamp, uid, uptime.
+# Only alert on specific events
+default["monit"]["alert_onlyif_events"] = []
+# Ignore alerts for specific events
 default["monit"]["alert_ignore_events"] = []
 
 # Email address that will be notified of events.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -89,7 +89,7 @@ default["monit"]["source_uninstall"] = false
 
 default["monit"]["source"]["version"] = "5.12.2"
 default["monit"]["source"]["prefix"] = "/usr/local"
-default["monit"]["source"]["url"] = "https://mmonit.com/monit/dist/monit-#{node['monit']['source']['version']}.tar.gz"
+default["monit"]["source"]["url"] = "https://mmonit.com/monit/dist/monit-#{node["monit"]["source"]["version"]}.tar.gz"
 default["monit"]["source"]["checksum"] = "8ab0296d1aa2351b1573481592d7b5e06de1edd49dff1b5552839605a450914c"
 default["monit"]["source"]["pam_support"] = true
 default["monit"]["source"]["ssl_support"] = true
@@ -102,5 +102,5 @@ default["monit"]["binary_uninstall"] = false
 
 default["monit"]["binary"]["version"] = "5.12.2"
 default["monit"]["binary"]["prefix"] = "/usr"
-default["monit"]["binary"]["url"] = "http://mmonit.com/monit/dist/binary/#{node['monit']['binary']['version']}/monit-#{node['monit']['binary']['version']}-linux-x64.tar.gz"
+default["monit"]["binary"]["url"] = "http://mmonit.com/monit/dist/binary/#{node["monit"]["binary"]["version"]}/monit-#{node["monit"]["binary"]["version"]}-linux-x64.tar.gz"
 default["monit"]["binary"]["checksum"] = "4908143752d0ee5081a50389a9206b7c905f9f8922a062a208fecf6e729a3c77"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -87,10 +87,10 @@ default["monit"]["version"] = nil
 default["monit"]["source_install"] = false
 default["monit"]["source_uninstall"] = false
 
-default["monit"]["source"]["version"] = "5.11"
+default["monit"]["source"]["version"] = "5.12.2"
 default["monit"]["source"]["prefix"] = "/usr/local"
-default["monit"]["source"]["url"] = "https://mmonit.com/monit/dist/monit-5.11.tar.gz"
-default["monit"]["source"]["checksum"] = "d507957b1e18e6f45af5a4d3f94529ab22b26f522f5f62287919bc905c44283a"
+default["monit"]["source"]["url"] = "https://mmonit.com/monit/dist/monit-#{node['monit']['source']['version']}.tar.gz"
+default["monit"]["source"]["checksum"] = "8ab0296d1aa2351b1573481592d7b5e06de1edd49dff1b5552839605a450914c"
 default["monit"]["source"]["pam_support"] = true
 default["monit"]["source"]["ssl_support"] = true
 default["monit"]["source"]["large_file_support"] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "github@phlippers.net"
 license           "MIT"
 description       "Configures monit"
 long_description  "Please refer to README.md"
-version           "1.5.4"
+version           "1.5.5"
 
 recipe "monit", "Sets up the service definition and default checks."
 recipe "monit::install_source", "Compiles and installs monit from source."

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "github@phlippers.net"
 license           "MIT"
 description       "Configures monit"
 long_description  "Please refer to README.md"
-version           "1.5.5"
+version           "1.5.6"
 
 recipe "monit", "Sets up the service definition and default checks."
 recipe "monit::install_source", "Compiles and installs monit from source."

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,6 +1,6 @@
 name              "monit"
-maintainer        "Rick Hull"
-maintainer_email  "rick.hull@glassdoor.com"
+maintainer        "Phil Cohen"
+maintainer_email  "github@phlippers.net"
 license           "MIT"
 description       "Configures monit"
 long_description  "Please refer to README.md"

--- a/templates/centos/monit.init.erb
+++ b/templates/centos/monit.init.erb
@@ -1,0 +1,72 @@
+#! /bin/sh
+#
+# monit         Monitor Unix systems
+#
+# Author:	Clinton Work,   <work@scripty.com>
+#
+# chkconfig:    2345 98 02
+# description:  Monit is a utility for managing and monitoring processes,
+#               files, directories and filesystems on a Unix system.
+# processname:  monit
+# pidfile:      /var/run/monit.pid
+# config:       /etc/monit.conf
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+# Source networking configuration.
+. /etc/sysconfig/network
+
+MONIT=/usr/bin/monit
+
+# Source monit configuration.
+if [ -f /etc/sysconfig/monit ] ; then
+        . /etc/sysconfig/monit
+fi
+
+CONFIG="<%= @config %>"
+MONIT_OPTS="-c $CONFIG $MONIT_OPTS"
+
+[ -f $MONIT ] || exit 0
+
+RETVAL=0
+
+# See how we were called.
+case "$1" in
+  start)
+        echo -n "Starting monit: "
+        daemon $NICELEVEL $MONIT $MONIT_OPTS
+        RETVAL=$?
+        echo
+        [ $RETVAL = 0 ] && touch /var/lock/subsys/monit
+        ;;
+  stop)
+        echo -n "Stopping monit: "
+        killproc monit
+        RETVAL=$?
+        echo
+        [ $RETVAL = 0 ] && rm -f /var/lock/subsys/monit
+        ;;
+  restart)
+        $0 stop
+        $0 start
+        RETVAL=$?
+        ;;
+  reload)
+        echo -n "Reloading monit: "
+        $MONIT $MONIT_OPTS reload
+        RETVAL=$?
+        ;;
+  condrestart)
+       [ -e /var/lock/subsys/monit ] && $0 restart
+       ;;
+  status)
+        status monit
+        RETVAL=$?
+        ;;
+  *)
+        echo "Usage: $0 {start|stop|restart|condrestart|status}"
+        exit 1
+esac
+
+exit $RETVAL

--- a/templates/default/monitrc.erb
+++ b/templates/default/monitrc.erb
@@ -23,7 +23,17 @@ set statefile <%= node["monit"]["statefile"] %>
 
 <% if node['monit']['mail_alerts'] %>
 # Mail alerts
-set alert <%= node["monit"]["alert_email"] %> <%= node["monit"]["alert_ignore_events"].empty? ? "" : "but not on { #{node["monit"]["alert_ignore_events"].join(", ")} }" %>
+<% alert_email_map = node['monit']['alert_email'] %>
+<% unless alert_email_map.is_a? Hash %>
+  <% alert_email_map = { alert_email_map => { 'onlyon_events' => node['monit']['alert_onlyon_events'], 'ignore_events' => node['monit']['alert_ignore_events'] } } %>
+<% end %>
+<% alert_email_map.each do |alert_emails, events_map| %>
+  <% onlyon = events_map['onlyon_events'].join(', ') rescue '' %>
+  <% ignore = events_map['ignore_events'].join(', ') rescue '' %>
+  <% (alert_emails.is_a?(Array) ? alert_emails : alert_emails.split(/[, ]+/)).each do |alert_email| %>
+set alert <%= alert_email %> <%= onlyon.empty? ? '' : "on { #{onlyon} }" %> <%= ignore.empty? ? '' : "but not on { #{ignore} }" %>
+  <% end %>
+<% end %>
 <% end %>
 
 set mailserver <%= node["monit"]["mail"]["hostname"] %> port <%= node["monit"]["mail"]["port"] %>


### PR DESCRIPTION
see https://github.com/phlipper/chef-monit/pull/65 for additional details

This PR has updates to keep travis happy, particularly with Ruby 2.2

I also notice that you have an `updates` branch.  However, it does not provide working binary URLs either, which is what prompted this fork (and PR).  We have been using eric239's fork, which adds proper Centos support, and updated (though now out-of-date) URLs.  This is the reasoning for ignoring the `updates` branch.

Are you able to maintain this project going forward?

