### PR TITLE
Fix converge error caused by overwriting runnig bin file

### DIFF
--- a/recipes/install_binary.rb
+++ b/recipes/install_binary.rb
@@ -5,12 +5,19 @@
 
 tar_file = "monit-#{node["monit"]["binary"]["version"]}.tar.gz"
 cache_path = Chef::Config[:file_cache_path]
+binary = "#{node["monit"]["binary"]["prefix"]}/bin/monit"
+
+execute "rm #{binary}" do
+  only_if { File.exist?(binary)} 
+  not_if "monit -V | grep #{node["monit"]["binary"]["version"]}"
+	notifies :create, "remote_file[#{cache_path}/#{tar_file}]", :immediately
+end
 
 remote_file "#{cache_path}/#{tar_file}" do
   source node["monit"]["binary"]["url"]
   checksum node["monit"]["binary"]["checksum"]
   action :create_if_missing
-  notifies :run, "execute[install-monit-binary]"
+  notifies :run, "execute[install-monit-binary]", :immediately
 end
 
 execute "install-monit-binary" do
@@ -20,8 +27,7 @@ execute "install-monit-binary" do
     "cd #{File.basename(tar_file, ".tar.gz")}",
     "cp bin/monit #{node["monit"]["binary"]["prefix"]}/bin/monit"
   ].join(" && ")
-  action :create_if_missing
-  #not_if do ::File.exists?("#{node["monit"]["binary"]["prefix"]}/bin/monit") end
+  action :nothing
 end
 
 include_recipe "monit::_service_configuration"

--- a/recipes/install_binary.rb
+++ b/recipes/install_binary.rb
@@ -20,8 +20,8 @@ execute "install-monit-binary" do
     "cd #{File.basename(tar_file, ".tar.gz")}",
     "cp bin/monit #{node["monit"]["binary"]["prefix"]}/bin/monit"
   ].join(" && ")
-  action :nothing
-  not_if do ::File.exists?("#{node["monit"]["binary"]["prefix"]}/bin/monit") end
+  action :create_if_missing
+  #not_if do ::File.exists?("#{node["monit"]["binary"]["prefix"]}/bin/monit") end
 end
 
 include_recipe "monit::_service_configuration"

--- a/recipes/install_binary.rb
+++ b/recipes/install_binary.rb
@@ -21,6 +21,7 @@ execute "install-monit-binary" do
     "cp bin/monit #{node["monit"]["binary"]["prefix"]}/bin/monit"
   ].join(" && ")
   action :nothing
+  not_if do ::File.exists?("#{node["monit"]["binary"]["prefix"]}/bin/monit") end
 end
 
 include_recipe "monit::_service_configuration"

--- a/spec/install_binary_spec.rb
+++ b/spec/install_binary_spec.rb
@@ -1,0 +1,72 @@
+require "spec_helper"
+
+describe "monit::install_binary" do
+  describe "when binary is not found" do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(file_cache_path: '/var/chef/cache') do |node|
+        node.set["monit"]["binary"]["version"] = "5.12.2"
+        node.set["monit"]["binary"]["prefix"] = "/usr"
+      end.converge(described_recipe)
+    end
+		
+    specify do
+    	allow(File).to receive(:exist?).and_call_original
+    	allow(File).to receive(:exist?).with('/usr/bin/monit').and_return(false)
+    	expect(chef_run).to_not run_execute("rm /usr/bin/monit")
+      
+      expect(chef_run).to create_remote_file_if_missing('/var/chef/cache/monit-5.12.2.tar.gz')
+      download = chef_run.remote_file('/var/chef/cache/monit-5.12.2.tar.gz')
+			expect(download).to notify('execute[install-monit-binary]').to(:run)
+      
+      expect(chef_run).to_not run_execute("install-monit-binary").with(cwd: "/var/chef/cache", command: "tar zxvf monit-5.12.2.tar.gz && cd monit-5.12.2 && cp bin/monit /usr/bin/monit")
+      expect(chef_run).to include_recipe('monit::_service_configuration')
+    end
+  end
+  
+  describe "when binary is found and installing version is different from existing binary" do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(file_cache_path: '/var/chef/cache') do |node|
+        node.set["monit"]["binary"]["version"] = '5.12.2'
+        node.set["monit"]["binary"]["prefix"] = '/usr'
+      end.converge(described_recipe)
+    end
+
+    specify do
+    	allow(File).to receive(:exist?).and_call_original
+    	allow(File).to receive(:exist?).with('/usr/bin/monit').and_return(true)    
+    	stub_command('monit -V | grep 5.12.2').and_return(false) # ex) 5.12.1 was installed
+    	
+      expect(chef_run).to run_execute('rm /usr/bin/monit')
+      remove_existing_binary = chef_run.execute('rm /usr/bin/monit')
+      expect(remove_existing_binary).to notify('remote_file[/var/chef/cache/monit-5.12.2.tar.gz]').to(:create).immediately
+      
+      download = chef_run.remote_file('/var/chef/cache/monit-5.12.2.tar.gz')
+      expect(download).to notify('execute[install-monit-binary]').to(:run).immediately
+      
+      expect(chef_run).to create_remote_file_if_missing('/var/chef/cache/monit-5.12.2.tar.gz')
+      
+      expect(chef_run).to_not run_execute("install-monit-binary").with(cwd: "/var/chef/cache", command: "tar zxvf monit-5.12.2.tar.gz && cd monit-5.12.2 && cp bin/monit /usr/bin/monit")
+      expect(chef_run).to include_recipe('monit::_service_configuration')
+    end
+  end  
+  
+  describe "when binary is found and installing version same as existing binary" do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(file_cache_path: '/var/chef/cache') do |node|
+        node.set["monit"]["binary"]["version"] = '5.12.2'
+        node.set["monit"]["binary"]["prefix"] = '/usr'
+      end.converge(described_recipe)
+    end
+
+    specify do
+    	allow(File).to receive(:exist?).and_call_original
+    	allow(File).to receive(:exist?).with('/usr/bin/monit').and_return(true)    
+    	stub_command('monit -V | grep 5.12.2').and_return(true)
+    	
+      expect(chef_run).not_to run_execute('rm /usr/bin/monit')
+      
+      expect(chef_run).to_not run_execute("install-monit-binary").with(cwd: "/var/chef/cache", command: "tar zxvf monit-5.12.2.tar.gz && cd monit-5.12.2 && cp bin/monit /usr/bin/monit")
+      expect(chef_run).to include_recipe('monit::_service_configuration')
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes problem happens during second and further converge, trying to overwrite monit binary file while the file is already opened and not writable.

The binary install recipe now detects following 3 cases and behaves differently:
case 1) Binary file not found
the recipe download binary and installs it
case 2) Binary file found and different version need to be installed
the recipe delete the binary file as there is case it's running and not writable, and download and installs new one
case 3) Binary file found and same version as the one to be installed
skips download and installation
   