### PR TITLE
fix guard and update monit binary version

### DIFF
--- a/recipes/install_binary.rb
+++ b/recipes/install_binary.rb
@@ -27,6 +27,8 @@ execute "install-monit-binary" do
     "cd #{File.basename(tar_file, ".tar.gz")}",
     "cp bin/monit #{node["monit"]["binary"]["prefix"]}/bin/monit"
   ].join(" && ")
+  not_if { ::File.exist?(binary) }
+  not_if "monit -V | grep #{node["monit"]["binary"]["version"]}"
   action :nothing
 end
 

--- a/spec/install_binary_spec.rb
+++ b/spec/install_binary_spec.rb
@@ -1,16 +1,16 @@
 require "spec_helper"
 
 describe "monit::install_binary" do
-  let(:monit_tarball) { "/var/chef/cache/monit-5.12.2.tar.gz" }
+  let(:monit_tarball) { "/var/chef/cache/monit-5.13.tar.gz" }
 
   let(:install_binary_command) do
-    "tar zxvf monit-5.12.2.tar.gz && cd monit-5.12.2 && cp bin/monit /usr/bin/monit" # rubocop:disable Metrics/LineLength
+    "tar zxvf monit-5.13.tar.gz && cd monit-5.13 && cp bin/monit /usr/bin/monit" # rubocop:disable Metrics/LineLength
   end
 
   describe "when binary is not found" do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(file_cache_path: "/var/chef/cache") do |node|
-        node.set["monit"]["binary"]["version"] = "5.12.2"
+        node.set["monit"]["binary"]["version"] = "5.13"
         node.set["monit"]["binary"]["prefix"] = "/usr"
       end.converge(described_recipe)
     end
@@ -37,7 +37,7 @@ describe "monit::install_binary" do
   describe "when binary is found and installing a different version" do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(file_cache_path: "/var/chef/cache") do |node|
-        node.set["monit"]["binary"]["version"] = "5.12.2"
+        node.set["monit"]["binary"]["version"] = "5.13"
         node.set["monit"]["binary"]["prefix"] = "/usr"
       end.converge(described_recipe)
     end
@@ -46,8 +46,8 @@ describe "monit::install_binary" do
       allow(::File).to receive(:exist?).and_call_original
       allow(::File).to receive(:exist?).with("/usr/bin/monit").and_return(true)
 
-      # example: 5.12.1 was installed
-      stub_command("monit -V | grep 5.12.2").and_return(false)
+      # example: 5.12.2 was installed
+      stub_command("monit -V | grep 5.13").and_return(false)
 
       expect(chef_run).to run_execute("rm /usr/bin/monit")
       remove_existing_binary = chef_run.execute("rm /usr/bin/monit")
@@ -77,7 +77,7 @@ describe "monit::install_binary" do
   describe "when binary is found and installing the same version" do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(file_cache_path: "/var/chef/cache") do |node|
-        node.set["monit"]["binary"]["version"] = "5.12.2"
+        node.set["monit"]["binary"]["version"] = "5.13"
         node.set["monit"]["binary"]["prefix"] = "/usr"
       end.converge(described_recipe)
     end
@@ -85,9 +85,9 @@ describe "monit::install_binary" do
     specify do
       allow(::File).to receive(:exist?).and_call_original
       allow(::File).to receive(:exist?).with("/usr/bin/monit").and_return(true)
-      stub_command("monit -V | grep 5.12.2").and_return(true)
+      stub_command("monit -V | grep 5.13").and_return(true)
 
-      expect(chef_run).not_to run_execute("rm /usr/bin/monit")
+      expect(chef_run).to_not run_execute("rm /usr/bin/monit")
 
       expect(chef_run).to_not(
         run_execute("install-monit-binary").with(


### PR DESCRIPTION
fixed guard because commit 1f90c6f9dbb04c8d1204677b5dbf7ff399b19e47 got following error 

```
       [2015-05-05T14:26:45+01:00] ERROR: Running exception handlers
       Running handlers complete
       [2015-05-05T14:26:45+01:00] ERROR: Exception handlers complete
       [2015-05-05T14:26:45+01:00] FATAL: Stacktrace dumped to /tmp/kitchen/cache/chef-stacktrace.out
       Chef Client failed. 5 resources updated in 30.117795356 seconds
       [2015-05-05T14:26:45+01:00] ERROR: execute[install-monit-binary] (monit::install_binary line 23) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '1'
       ---- Begin output of tar zxvf monit-5.12.2.tar.gz && cd monit-5.12.2 && cp bin/monit /usr/bin/monit ----
       STDOUT: monit-5.12.2/
       monit-5.12.2/bin/
       monit-5.12.2/bin/monit
       monit-5.12.2/COPYING
       monit-5.12.2/conf/
       monit-5.12.2/conf/monitrc
       monit-5.12.2/man/
       monit-5.12.2/man/man1/
       monit-5.12.2/man/man1/monit.1
       STDERR: cp: cannot create regular file `/usr/bin/monit': Text file busy
       ---- End output of tar zxvf monit-5.12.2.tar.gz && cd monit-5.12.2 && cp bin/monit /usr/bin/monit ----
       Ran tar zxvf monit-5.12.2.tar.gz && cd monit-5.12.2 && cp bin/monit /usr/bin/monit returned 1
       [2015-05-05T14:26:47+01:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)

```
