### PR TITLE
apt cookbook include is problematic

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -3,8 +3,6 @@
 # Recipe:: default
 #
 
-include_recipe "apt" if platform_family?("debian") # ~FC007 uses `suggests`
-
 if node["monit"]["source_install"]
   include_recipe "monit::install_source"
 elsif node["monit"]["binary_install"]

--- a/recipes/install_package.rb
+++ b/recipes/install_package.rb
@@ -3,7 +3,12 @@
 # Recipe:: install_package
 #
 
-include_recipe "yum-epel" if platform_family?("rhel") # ~FC007 uses `suggests`
+case node["platform_family"] # ~FC007 uses `suggests`
+when "debian"
+  include_recipe "apt"
+when "rhel"
+  include_recipe "yum-epel"
+end
 
 package "monit" do
   version node["monit"]["version"] if node["monit"]["version"]


### PR DESCRIPTION
The metadata file suggests the **apt** cookbook rather than depending on it. This configuration makes sense since that cookbook is not needed when installing Monit from source (possibly binary as well). However, in the default recipe, we see an `include_recipe "apt"` call for any Debian platform regardless of the install strategy. Based on the layout of the recipes in this cookbook, users should use the **default** recipe and trigger different installs using attribute values instead of invoking the **install_{source,package,binary}** recipes directly.

Moving this include statement inside the **install_package** recipe remedies this problem without breaking existing functionality. 
