### PR TITLE
Add support for custom include paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ else
   default["monit"]["includes_dir"] = "/etc/monit/conf.d"
 end
 
+# Custom include paths.
+default["monit"]["includes"] = []
+
 # The monit::default recipe will load these monit_monitrc resources automatically
 # NOTE setting this attribute at the default level will append values to the array
 default["monit"]["default_monitrc_configs"] = %w[load ssh]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -71,6 +71,7 @@ else
   default["monit"]["includes_dir"] = "/etc/monit/conf.d"
 end
 
+# Custom include paths.
 default["monit"]["includes"] = []
 
 # The monit::default recipe will load these monit_monitrc resources automatically

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -71,6 +71,8 @@ else
   default["monit"]["includes_dir"] = "/etc/monit/conf.d"
 end
 
+default["monit"]["includes"] = []
+
 # The monit::default recipe will load these monit_monitrc resources automatically
 # NOTE setting this attribute at the default level will append values to the array
 default["monit"]["default_monitrc_configs"] = %w[load ssh]

--- a/templates/default/monitrc.erb
+++ b/templates/default/monitrc.erb
@@ -72,4 +72,9 @@ set httpd port <%= node["monit"]["web_interface"]["port"] %>
 <% end %>
 
 # Include config files
-include <%= node["monit"]["includes_dir"] %>/*
+include "<%= node["monit"]["includes_dir"] %>/*"
+<% if node["monit"]["includes"] && node["monit"]["includes"].size > 0 %>
+  <% node["monit"]["includes"].each do |path| %>
+include "<%= path %>"
+  <% end %>
+<% end %>


### PR DESCRIPTION
For example using Dokku and it's monit plugin, I need to specifically include "/home/dokku/*/monitrc" which wasn't possible previously.

P.S. Just noticed that I'd also wrapped the include valus in double quotes. Let me know if you want me to remove that change from the PR.
