### PR TITLE
Fixes binary path prefix regression

### DIFF
--- a/recipes/_service_configuration.rb
+++ b/recipes/_service_configuration.rb
@@ -16,11 +16,14 @@ monit_dirs.each do |dir|
   end
 end
 
+binary_prefix = node["monit"]["source_install"] ?
+  node["monit"]["source"]["prefix"] : node["monit"]["binary"]["prefix"]
+
 template "/etc/init.d/monit" do
   source "monit.init.erb"
   mode "0755"
   variables(
-    prefix: node["monit"]["binary"]["prefix"],
+    prefix: binary_prefix,
     config: node["monit"]["main_config_path"],
     pidfile: node["monit"]["pidfile"]
   )

--- a/recipes/_service_configuration.rb
+++ b/recipes/_service_configuration.rb
@@ -16,8 +16,12 @@ monit_dirs.each do |dir|
   end
 end
 
-binary_prefix = node["monit"]["source_install"] ?
-  node["monit"]["source"]["prefix"] : node["monit"]["binary"]["prefix"]
+binary_prefix = \
+  if node["monit"]["source_install"]
+    node["monit"]["source"]["prefix"]
+  else
+    node["monit"]["binary"]["prefix"]
+  end
 
 template "/etc/init.d/monit" do
   source "monit.init.erb"

--- a/spec/install_binary_spec.rb
+++ b/spec/install_binary_spec.rb
@@ -7,6 +7,20 @@ describe "monit::install_binary" do
     "tar zxvf monit-5.12.2.tar.gz && cd monit-5.12.2 && cp bin/monit /usr/bin/monit" # rubocop:disable Metrics/LineLength
   end
 
+  # shared behavior
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new(file_cache_path: "/var/chef/cache") do |node|
+      node.set["monit"]["binary_install"] = true
+    end.converge(described_recipe)
+  end
+
+  specify do
+    expect(chef_run).to create_template("/etc/init.d/monit").
+      with_variables lambda { |x|
+        expect(x).to include(prefix: chef_run.node["monit"]["binary"]["prefix"])
+      }
+  end
+
   describe "when binary is not found" do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(file_cache_path: "/var/chef/cache") do |node|

--- a/spec/install_source_spec.rb
+++ b/spec/install_source_spec.rb
@@ -69,5 +69,9 @@ describe "monit::install_source" do
       source: "monit.init.erb",
       mode: "0755"
     )
+    expect(chef_run).to create_template("/etc/init.d/monit").
+      with_variables lambda { |x|
+        expect(x).to include(prefix: chef_run.node["monit"]["source"]["prefix"])
+      }
   end
 end


### PR DESCRIPTION
Whenever the private recipe `_service_configuration.rb` was created, the monit path prefix set to the value for **binary** installs. This change toggles the prefix based on whether the install is from a **source** tarball or binary.
