### PR TITLE
Add Systemd support for debian 8

### DIFF
--- a/templates/default/monit.systemd.erb
+++ b/templates/default/monit.systemd.erb
@@ -1,0 +1,30 @@
+ <% monit_bin = ::File.join(@prefix, "bin", "monit") %>
+ # This file is systemd template for monit service. To
+ # register # monit with systemd, place the monit.servicefile
+ # to the /lib/systemd/system/ directory and then start it
+ # using systemctl (see bellow).
+ #
+ # Enable monit to start on boot:
+ #         systemctl enable monit.service
+ #
+ # Start monit immediately:
+ #         systemctl start monit.service
+ #
+ # Stop monit:
+ #         systemctl stop monit.service
+ #
+ # Status:
+ #         systemctl status monit.service
+
+ [Unit]
+ Description=Pro-active monitoring utility for unix systems
+ After=network.target
+
+ [Service]
+ Type=simple
+ ExecStart=<%= monit_bin %> -I -c <%= @config %> <%= @opts %>
+ ExecStop=<%= monit_bin %> quit
+ ExecReload=<%= monit_bin %> reload
+
+ [Install]
+ WantedBy=multi-user.target


### PR DESCRIPTION
I really want to start a discussion topic here.  It turns out that most major distros are adopting systemd as the default init system (e.g. Debian, Ubuntu, RHEL, CentOS, SUSE).

The changes I added are specifically tied to Debian 8 but perhaps there's a more "inclusive" change that will allow the cookbook consumer to indicate that systemd is the preferred init system. We could always do a programmatic check but that may be slightly more complicated.

Thoughts?
