### PR TITLE
Fixes for binary install

### DIFF
--- a/recipes/install_binary.rb
+++ b/recipes/install_binary.rb
@@ -9,7 +9,7 @@ binary = "#{node["monit"]["binary"]["prefix"]}/bin/monit"
 
 execute "rm #{binary}" do
   only_if { ::File.exist?(binary) }
-  not_if "monit -V | grep #{node["monit"]["binary"]["version"]}"
+  not_if "#{node["monit"]["binary"]["prefix"]}/bin/monit -V | grep #{node["monit"]["binary"]["version"]}"
   notifies :create, "remote_file[#{cache_path}/#{tar_file}]", :immediately
 end
 

--- a/templates/centos/monit.init.erb
+++ b/templates/centos/monit.init.erb
@@ -17,7 +17,7 @@
 # Source networking configuration.
 . /etc/sysconfig/network
 
-MONIT=/usr/bin/monit
+MONIT="<%= @prefix %>/bin/monit"
 
 # Source monit configuration.
 if [ -f /etc/sysconfig/monit ] ; then


### PR DESCRIPTION
1. Adjusted the init script for CentOS to support setting via attribute.
2. added full path to the execute command to protect the binary from being removed if the monit binary is not in the $PATH.
   
   Let me know if anything else is needed/required. 
   Steve
