### PR TITLE
Make statefile dir

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -48,6 +48,12 @@ directory "/var/monit" do
   mode  "0700"
 end
 
+if state_file = node["monit"]["statefile"]
+  directory state_file.split("/")[0..-2].join('/') do
+    recursive true
+  end
+end
+
 # enable service startup
 file "/etc/default/monit" do
   owner "root"


### PR DESCRIPTION
遅くなりましたが、forkしたmonit本家追従の件対応いたしました。

対象Branchで変更される箇所としては、[/etc/monit.conf]へpidfileのpathが
明示的に追記される点のみとなります。cookした場合はrestartが走りますが..

```
+# Set location of Monit pid file
+set pidfile /var/run/monit.pid
+
```

また、include_recipeとしてmonitを利用している各recipeで生成されるファイル群も
現行の利用方法で特に影響なく生成されていることを確認できております。

お手すきの際レビューお願いします。
