### PR TITLE
Use 'use_inline_resources' to ensure notifications propagate correctly

### DIFF
--- a/providers/monitrc.rb
+++ b/providers/monitrc.rb
@@ -2,10 +2,12 @@ def whyrun_supported?
   true
 end
 
+use_inline_resources
+
 action :create do
   name = new_resource.name
 
-  t = template "#{node["monit"]["includes_dir"]}/#{name}.monitrc" do
+  template "#{node["monit"]["includes_dir"]}/#{name}.monitrc" do
     owner "root"
     group "root"
     mode  "0644"
@@ -13,23 +15,13 @@ action :create do
     cookbook new_resource.template_cookbook
     variables new_resource.variables
     notifies :reload, "service[monit]" if node["monit"]["reload_on_change"]
-    action :nothing
+    action :create
   end
-
-  # Run the action immediately so `updated_by_last_action?` is correct
-  t.run_action(:create)
-
-  new_resource.updated_by_last_action(t.updated_by_last_action?)
 end
 
 action :delete do
-  f = file "#{node["monit"]["includes_dir"]}/#{new_resource.name}.monitrc" do
-    action :nothing
+  file "#{node["monit"]["includes_dir"]}/#{new_resource.name}.monitrc" do
+    action :delete
     notifies :reload, "service[monit]"
   end
-
-  # Run the action immediately so `updated_by_last_action?` is correct
-  f.run_action(:delete)
-
-  new_resource.updated_by_last_action(f.updated_by_last_action?)
 end


### PR DESCRIPTION
PR #69 updated the monit provider to use `run_action` on the provided resources to make external notifications propagate (i.e., so that a 'notifies' in a `monit_monitrc`'s block would run). But that has the side effect of not firing the 'notifies' inside the `monit_monitrc` resource, and thus monit never reloads when a new `monit_monitrc` resource is created.

This uses `use_inline_resources` to evaluate the monit template in its own context, so that that context will fire notifications declared on the `monit_monitrc` resource, while still firing the notification on the template itself.

Tested against Chef 12.14.68, 12.21.1 (current) , 13.1.31 (current). 